### PR TITLE
#1 search and result are with same width now

### DIFF
--- a/Search Bar/react-search-bar/src/App.css
+++ b/Search Bar/react-search-bar/src/App.css
@@ -8,4 +8,5 @@
 h1 {
   font-size: 3.2em;
   line-height: 1.1;
+  font-family: Arial, Helvetica, sans-serif;
 }

--- a/Search Bar/react-search-bar/src/Components/Search.css
+++ b/Search Bar/react-search-bar/src/Components/Search.css
@@ -2,13 +2,16 @@
     background-color: whitesmoke;
     max-width: 100%;
     min-width: 200px;
-    padding: 5px;
+    padding: 15px;
     display: flex;
     align-items: center;
+    border-radius: 10px 10px 0 0;
 }
 
 input{
     background-color: transparent;
+    border-radius: 12px;
+
     border: none;
     height: 100%;
     width: 100%;

--- a/Search Bar/react-search-bar/src/Components/Search.css
+++ b/Search Bar/react-search-bar/src/Components/Search.css
@@ -1,6 +1,6 @@
 #searchBar{
     background-color: whitesmoke;
-    width: 100%;
+    max-width: 100%;
     min-width: 200px;
     padding: 5px;
     display: flex;

--- a/Search Bar/react-search-bar/src/Components/SearchResults.css
+++ b/Search Bar/react-search-bar/src/Components/SearchResults.css
@@ -5,10 +5,18 @@
     display: flex;
     flex-direction: column;
     box-shadow: 0px 0px 8px #ddd;
-    border-radius: 10px;
+    border-radius:0 0 10px 10px;
     /* margin-top: 1rem; */
     max-height: 300px;
     overflow-y: scroll;
+}
+
+.result-list {
+    -ms-overflow-style: none;  /* Internet Explorer 10+ */
+    scrollbar-width: none;  /* Firefox */
+}
+.result-list::-webkit-scrollbar { 
+    display: none;  /* Safari and Chrome */
 }
 
 .resultOnly{


### PR DESCRIPTION
## Pull Request for Fixing Issue #1
## Description
In this pull request, I have fixed issue #1, where the search bar and search results had mismatched widths. The root cause of the bug was that both elements were set to a width of 100%, but the search bar had padding, which was causing an overflow issue. To address this, I have changed the width property from 100% to max-width: 100%.

## Changes Made
Modified the CSS for the search bar and search results to set max-width: 100% instead of width: 100%.

## Screen of result

**Desktop**
![Screenshot 2023-10-13 143955](https://github.com/pushsontakke/Practices/assets/79264045/2c33997f-73ec-46ca-bc2d-6c9082180724)
![Screenshot 2023-10-13 144026](https://github.com/pushsontakke/Practices/assets/79264045/9e1928fa-117a-43d0-ab41-2ff19129b3e3)


**Mobile**


## Additional Considerations
I highly recommend that before proceeding any further, you take some time to improve the overall quality of the application by adhering to best practices for fetching and displaying data. The current code is not clean or scalable, and this may lead to numerous issues when adding new features in the future. Prioritizing clean code and scalability will help us avoid potential problems down the road.

Please review and merge this pull request as it fixes the immediate issue, and consider the long-term benefits of code cleanliness and scalability for the project.

Thank you!